### PR TITLE
PCSRE-969 Migrate WhiteSource config file to JSON

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -1,8 +1,8 @@
-##########################################################
-#### WhiteSource "Bolt for Github" configuration file ####
-##########################################################
-
-# Configuration #
-#---------------#
-ws.repo.scan=true
-vulnerable.check.run.conclusion.level=success
+{
+    "checkRunSettings": {
+        "vulnerableCheckRunConclusionLevel": "success"
+    },
+    "issueSettings": {
+        "minSeverityLevel": "LOW"
+    }
+}


### PR DESCRIPTION
- WhiteSource is following an old config
- Causes the WhiteSource tests to fail:
![image](https://user-images.githubusercontent.com/39657032/163030679-b15dfa61-9464-4bfa-8d3c-0b5cfdfa6255.png)

- Needs to update to JsonObject format for unit tests to pass
- Referenced the code in https://github.com/clearcare/wyoming_ope/blob/master/.whitesource